### PR TITLE
Microsoft minidriver

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5595,8 +5595,7 @@ static int piv_match_card_continued(sc_card_t *card)
                                     (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
-						
-						card->mgmt_key_alg = piv_get_management_key_algorithm(card);
+                        card->mgmt_key_alg = piv_get_management_key_algorithm(card);
         }
 
         sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -4455,7 +4455,7 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	}
 
 	/* NIST 800-73-3 says use 9B, previous versions used 00 */
-	r = piv_general_io(card, 0x87, 0x00, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
+	r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
 	/*
 	 * piv_get_challenge is called in a loop.
 	 * some cards may allow 1 challenge expecting it to be part of
@@ -4497,28 +4497,35 @@ err:
 static int piv_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len)
 {
     u8 sbuf[4096];
+    u8 inner_buf[4096];
     int r;
-    u8 *p;
-    piv_private_data_t * priv = PIV_DATA(card);
-    
+    u8 *p_outer, *p_inner;
+    piv_private_data_t *priv = PIV_DATA(card);
+
     LOG_FUNC_CALLED(card->ctx);
 
-    // Build the TLV structure
-    p = sbuf;
-    
-    // Create 7C TLV wrapper
-    r = sc_asn1_put_tag(0x7C, NULL, response_data_len + 2, p, sizeof(sbuf), &p);
+    // Build inner TLV: 82 <len> <response_data>
+    p_inner = inner_buf;
+    r = sc_asn1_put_tag(0x82, response_data, response_data_len,
+                        p_inner, sizeof(inner_buf), &p_inner);
     if (r != SC_SUCCESS)
         LOG_FUNC_RETURN(card->ctx, r);
-        
-    // Create 82 TLV for the challenge response
-    r = sc_asn1_put_tag(0x82, response_data, response_data_len, p, sizeof(sbuf) - (p - sbuf), &p);
+
+    size_t inner_len = p_inner - inner_buf;
+
+    // Build outer TLV: 7C <len> <inner_tlv>
+    p_outer = sbuf;
+    r = sc_asn1_put_tag(0x7C, inner_buf, inner_len,
+                        p_outer, sizeof(sbuf), &p_outer);
     if (r != SC_SUCCESS)
         LOG_FUNC_RETURN(card->ctx, r);
-        
+
+    size_t total_len = p_outer - sbuf;
+
     // Send GENERAL AUTHENTICATE command
-    r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, p - sbuf, NULL, 0);
-    
+    r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B,
+                       sbuf, total_len, NULL, 0);
+
     LOG_FUNC_RETURN(card->ctx, r);
 }
 
@@ -5588,6 +5595,8 @@ static int piv_match_card_continued(sc_card_t *card)
                                     (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
+						
+						card->mgmt_key_alg = piv_get_management_key_algorithm(card);
         }
 
         sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
@@ -5981,8 +5990,7 @@ static int piv_init(sc_card_t *card)
 	 */
 	piv_process_history(card);
 
-	priv->mgmt_key_alg = piv_get_management_key_algorithm(card);
-
+	priv->mgmt_key_alg = 0;
 	priv->pstate=PIV_STATE_NORMAL;
 	sc_unlock(card);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -851,6 +851,7 @@ static int piv_cache_internal_data(sc_card_t *card, int enumtag);
 static int piv_logout(sc_card_t *card);
 static int piv_match_card_continued(sc_card_t *card);
 static int piv_obj_cache_free_entry(sc_card_t *card, int enumtag, int flags);
+static u8 piv_get_management_key_algorithm(sc_card_t *card);
 
 #ifdef ENABLE_PIV_SM
 static void piv_inc(u8 *counter, size_t size);
@@ -4494,39 +4495,44 @@ err:
 
 }
 
-static int piv_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len)
+static int
+piv_authenticate_challenge(sc_card_t *card, const u8 *buf, size_t count)
 {
-    u8 sbuf[4096];
-    u8 inner_buf[4096];
-    int r;
-    u8 *p_outer, *p_inner;
-    piv_private_data_t *priv = PIV_DATA(card);
+	u8 sbuf[4096];
+	int r;
+	u8 *p;
+	piv_private_data_t *priv = PIV_DATA(card);
 
-    LOG_FUNC_CALLED(card->ctx);
+	LOG_FUNC_CALLED(card->ctx);
 
-    // Build inner TLV: 82 <len> <response_data>
-    p_inner = inner_buf;
-    r = sc_asn1_put_tag(0x82, response_data, response_data_len,
-                        p_inner, sizeof(inner_buf), &p_inner);
-    if (r != SC_SUCCESS)
-        LOG_FUNC_RETURN(card->ctx, r);
+	size_t inner_len, outer_len;
 
-    size_t inner_len = p_inner - inner_buf;
+	r = sc_asn1_put_tag(0x82, NULL, count,
+			NULL, 0, NULL);
+	LOG_TEST_RET(card->ctx, r, "Error handling TLV.");
+	inner_len = (size_t)r;
 
-    // Build outer TLV: 7C <len> <inner_tlv>
-    p_outer = sbuf;
-    r = sc_asn1_put_tag(0x7C, inner_buf, inner_len,
-                        p_outer, sizeof(sbuf), &p_outer);
-    if (r != SC_SUCCESS)
-        LOG_FUNC_RETURN(card->ctx, r);
+	r = sc_asn1_put_tag(0x7C, NULL, inner_len,
+			NULL, 0, NULL);
+	LOG_TEST_RET(card->ctx, r, "Error handling TLV.");
+	outer_len = (size_t)r;
 
-    size_t total_len = p_outer - sbuf;
+	if (outer_len > sizeof(sbuf))
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_BUFFER_TOO_SMALL);
 
-    // Send GENERAL AUTHENTICATE command
-    r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B,
-                       sbuf, total_len, NULL, 0);
+	p = sbuf;
+	r = sc_asn1_put_tag(0x7C, NULL, inner_len,
+			p, sizeof(sbuf), &p);
+	LOG_TEST_RET(card->ctx, r, "Error handling TLV.");
+	r = sc_asn1_put_tag(0x82, buf, count,
+			p, sizeof(sbuf) - (p - sbuf), &p);
+	LOG_TEST_RET(card->ctx, r, "Error handling TLV.");
+	size_t total_len = p - sbuf;
 
-    LOG_FUNC_RETURN(card->ctx, r);
+	r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B,
+			sbuf, total_len, NULL, 0);
+
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 static int
@@ -5595,7 +5601,7 @@ static int piv_match_card_continued(sc_card_t *card)
                                     (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
-                        card->mgmt_key_alg = piv_get_management_key_algorithm(card);
+                        priv->mgmt_key_alg = piv_get_management_key_algorithm(card);
         }
 
         sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
@@ -5797,50 +5803,39 @@ err:
 /*
  * Get the algorithm of the management key for admin operations.
  */
-static u8 piv_get_management_key_algorithm(sc_card_t *card) {
-  int r;
+static u8
+piv_get_management_key_algorithm(sc_card_t *card)
+{
+	int r;
 
-  sc_apdu_t apdu;
-  sc_format_apdu(card, &apdu,
-                 SC_APDU_CASE_2_SHORT, // command with output data only
-                 0xF7,                 // INS: GET METADATA Card Command
-                 0x00,                 // P1
-                 0x9B                  // P2
-  );
+	sc_apdu_t apdu;
+	sc_format_apdu(card, &apdu,
+			SC_APDU_CASE_2_SHORT, // command with output data only
+			0xF7,		      // INS: GET METADATA Card Command
+			0x00,		      // P1
+			0x9B		      // P2
+	);
 
-  // The GET METADATA response for the management key slot consists of a list of
-  // TLVs. For the slot 0x9B, 4 tags are supported:
-  // 1. 0x01: Algorithm of the key
-  // 2. 0x02: PIN and touch policy
-  // 3. 0x03: Origin of the key
-  // 4. 0x05: Whether the management key has default value
-  //
-  // The response consists of 10 bytes:
-  //  - the algorithm TLV has 3 bytes (1 byte tag + 1 byte len + 1 byte length)
-  //  - the PIN and touch policy TLV has 4 bytes (1 byte tag + 1 byte len + 2
-  //  byte data)
-  //  - the origin TLV has 3 bytes (1 byte tag + 1 byte len + 1 byte data)
-  //  - the default TLV has 3 bytes (1 byte tag + 1 byte len + 1 byte data)
-  unsigned char rbuf[13];
-  apdu.resp = rbuf;
-  apdu.resplen = sizeof(rbuf);
-  apdu.le = sizeof(rbuf);
+	unsigned char rbuf[13];
+	apdu.resp = rbuf;
+	apdu.resplen = sizeof(rbuf);
+	apdu.le = sizeof(rbuf);
 
-  r = sc_transmit_apdu(card, &apdu);
-  LOG_TEST_RET(card->ctx, r, "Transmit GET METADATA APDU failed");
+	r = sc_transmit_apdu(card, &apdu);
+	LOG_TEST_RET(card->ctx, r, "Transmit GET METADATA APDU failed");
 
-  r = sc_check_sw(card, apdu.sw1, apdu.sw2);
-  LOG_TEST_RET(card->ctx, r, "GET METADATA command failed");
+	r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+	LOG_TEST_RET(card->ctx, r, "GET METADATA command failed");
 
-  size_t algorithm_tag_len;
-  const u8 *algorithm;
-  algorithm = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0x01,
-                               &algorithm_tag_len);
-  if (!algorithm || algorithm_tag_len != 1) {
-    sc_log(card->ctx, "Cannot get key management algorithm");
-    LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ASN1_OBJECT);
-  }
-  return *algorithm;
+	size_t algorithm_tag_len;
+	const u8 *algorithm;
+	algorithm = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0x01,
+			&algorithm_tag_len);
+	if (!algorithm || algorithm_tag_len != 1) {
+		sc_log(card->ctx, "Cannot get key management algorithm");
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ASN1_OBJECT);
+	}
+	return *algorithm;
 }
 
 static int piv_init(sc_card_t *card)

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5832,8 +5832,8 @@ piv_get_management_key_algorithm(sc_card_t *card)
 	algorithm = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0x01,
 			&algorithm_tag_len);
 	if (!algorithm || algorithm_tag_len != 1) {
-		sc_log(card->ctx, "Cannot get key management algorithm");
-		LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ASN1_OBJECT);
+		sc_log(card->ctx, "Cannot get key management algorithm, using default");
+		return 0;
 	}
 	return *algorithm;
 }

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -4468,7 +4468,7 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 		 r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
 		 if (r == SC_ERROR_INCORRECT_PARAMETERS) {
 			 r = SC_ERROR_NOT_SUPPORTED;
-		}
+		 }
 	}
 	LOG_TEST_GOTO_ERR(card->ctx, r, "GENERAL AUTHENTICATE failed");
 
@@ -4699,7 +4699,7 @@ piv_compute_signature(sc_card_t *card, const u8 * data, size_t datalen,
 	 * and pad on left if too short.
 	 */
 
-	if (priv->alg_id == 0x11 || priv->alg_id == 0x14 ) {
+	if (priv->alg_id == 0x11 || priv->alg_id == 0x14) {
 		nLen = BYTES4BITS(priv->key_size);
 		if (outlen < 2*nLen) {
 			sc_log(card->ctx,
@@ -5602,14 +5602,14 @@ static int piv_match_card_continued(sc_card_t *card)
                                     (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
-                       piv_process_management_key_algorithm(card);
-        }
+			piv_process_management_key_algorithm(card);
+	}
 
-       sc_log(card->ctx, "Management key algorithm is 0x%08x",priv->mgmt_key_alg);
-       sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
+	sc_log(card->ctx, "Management key algorithm is 0x%08x", priv->mgmt_key_alg);
+	sc_debug(card->ctx, SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
 
-	 /* We now know PIV AID is active, test CCC object. 800-73-* say CCC is required */
-	 /* CCC not readable over contactless, unless using VCI. but dont need CCC for SC_CARD_TYPE_PIV_II_800_73_4 */
+	/* We now know PIV AID is active, test CCC object. 800-73-* say CCC is required */
+	/* CCC not readable over contactless, unless using VCI. but dont need CCC for SC_CARD_TYPE_PIV_II_800_73_4 */
 	switch (card->type) {
 		/*
 		 * For cards that may also be CAC, try and read the CCC

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -4465,9 +4465,9 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	 * Now that the card returned error, we can try one more time.
 	 */
 	 if (r == SC_ERROR_INCORRECT_PARAMETERS) {
-		r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
-		if (r == SC_ERROR_INCORRECT_PARAMETERS) {
-			r = SC_ERROR_NOT_SUPPORTED;
+		 r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
+		 if (r == SC_ERROR_INCORRECT_PARAMETERS) {
+			 r = SC_ERROR_NOT_SUPPORTED;
 		}
 	}
 	LOG_TEST_GOTO_ERR(card->ctx, r, "GENERAL AUTHENTICATE failed");
@@ -5602,11 +5602,11 @@ static int piv_match_card_continued(sc_card_t *card)
                                     (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
-                        piv_process_management_key_algorithm(card);
+                       piv_process_management_key_algorithm(card);
         }
 
-        sc_log(card->ctx, "Management key algorithm is 0x%08x",priv->mgmt_key_alg);
-        sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
+       sc_log(card->ctx, "Management key algorithm is 0x%08x",priv->mgmt_key_alg);
+       sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
 
 	 /* We now know PIV AID is active, test CCC object. 800-73-* say CCC is required */
 	 /* CCC not readable over contactless, unless using VCI. but dont need CCC for SC_CARD_TYPE_PIV_II_800_73_4 */

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -851,7 +851,7 @@ static int piv_cache_internal_data(sc_card_t *card, int enumtag);
 static int piv_logout(sc_card_t *card);
 static int piv_match_card_continued(sc_card_t *card);
 static int piv_obj_cache_free_entry(sc_card_t *card, int enumtag, int flags);
-static u8 piv_get_management_key_algorithm(sc_card_t *card);
+static int piv_process_management_key_algorithm(sc_card_t *card);
 
 #ifdef ENABLE_PIV_SM
 static void piv_inc(u8 *counter, size_t size);
@@ -5514,6 +5514,7 @@ static int piv_match_card_continued(sc_card_t *card)
 	/* TODO Dual CAC/PIV are bases on 800-73-1 where priv->pin_preference = 0. need to check later */
 	priv->logged_in = SC_PIN_STATE_UNKNOWN;
 	priv->pstate = PIV_STATE_MATCH;
+	priv->mgmt_key_alg = 0;
 
 #ifdef ENABLE_PIV_SM
 	memset(&card->sm_ctx, 0, sizeof card->sm_ctx);
@@ -5601,9 +5602,10 @@ static int piv_match_card_continued(sc_card_t *card)
                                     (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
-                        priv->mgmt_key_alg = piv_get_management_key_algorithm(card);
+                        piv_process_management_key_algorithm(card);
         }
 
+        sc_log(card->ctx, "Management key algorithm is 0x%08x",priv->mgmt_key_alg);
         sc_debug(card->ctx,SC_LOG_DEBUG_MATCH, "PIV_MATCH card->type:%d r2:%d CI:%08x r:%d\n", card->type, r2, priv->card_issues, r);
 
 	 /* We now know PIV AID is active, test CCC object. 800-73-* say CCC is required */
@@ -5803,8 +5805,8 @@ err:
 /*
  * Get the algorithm of the management key for admin operations.
  */
-static u8
-piv_get_management_key_algorithm(sc_card_t *card)
+static int
+piv_process_management_key_algorithm(sc_card_t *card)
 {
 	int r;
 
@@ -5832,10 +5834,13 @@ piv_get_management_key_algorithm(sc_card_t *card)
 	algorithm = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0x01,
 			&algorithm_tag_len);
 	if (!algorithm || algorithm_tag_len != 1) {
-		sc_log(card->ctx, "Cannot get key management algorithm, using default");
-		return 0;
+		sc_log(card->ctx, "Cannot get key management algorithm.");
+		return SC_ERROR_ASN1_OBJECT_NOT_FOUND;
 	}
-	return *algorithm;
+
+	piv_private_data_t *priv = PIV_DATA(card);
+	priv->mgmt_key_alg = *algorithm;
+	return SC_SUCCESS;
 }
 
 static int piv_init(sc_card_t *card)
@@ -5984,7 +5989,6 @@ static int piv_init(sc_card_t *card)
 	 */
 	piv_process_history(card);
 
-	priv->mgmt_key_alg = 0;
 	priv->pstate=PIV_STATE_NORMAL;
 	sc_unlock(card);
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -415,6 +415,7 @@ typedef struct piv_private_data {
 	unsigned int pin_policy; /* from discovery */
 	unsigned int init_flags;
 	u8  csID; /* 800-73-4 Cipher Suite ID 0x27 or 0x2E */
+	u8 mgmt_key_alg;
 #ifdef ENABLE_PIV_SM
 	cipher_suite_t *cs; /* active cipher_suite */
 	piv_cvc_t sm_cvc;  /* 800-73-4:  SM CVC Table 15 */
@@ -4463,7 +4464,7 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	 * Now that the card returned error, we can try one more time.
 	 */
 	 if (r == SC_ERROR_INCORRECT_PARAMETERS) {
-		r = piv_general_io(card, 0x87, 0x00, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
+		r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, sizeof sbuf, rbuf, sizeof rbuf);
 		if (r == SC_ERROR_INCORRECT_PARAMETERS) {
 			r = SC_ERROR_NOT_SUPPORTED;
 		}
@@ -4491,6 +4492,34 @@ static int piv_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 err:
 	LOG_FUNC_RETURN(card->ctx, r);
 
+}
+
+static int piv_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len)
+{
+    u8 sbuf[4096];
+    int r;
+    u8 *p;
+    piv_private_data_t * priv = PIV_DATA(card);
+    
+    LOG_FUNC_CALLED(card->ctx);
+
+    // Build the TLV structure
+    p = sbuf;
+    
+    // Create 7C TLV wrapper
+    r = sc_asn1_put_tag(0x7C, NULL, response_data_len + 2, p, sizeof(sbuf), &p);
+    if (r != SC_SUCCESS)
+        LOG_FUNC_RETURN(card->ctx, r);
+        
+    // Create 82 TLV for the challenge response
+    r = sc_asn1_put_tag(0x82, response_data, response_data_len, p, sizeof(sbuf) - (p - sbuf), &p);
+    if (r != SC_SUCCESS)
+        LOG_FUNC_RETURN(card->ctx, r);
+        
+    // Send GENERAL AUTHENTICATE command
+    r = piv_general_io(card, 0x87, priv->mgmt_key_alg, 0x9B, sbuf, p - sbuf, NULL, 0);
+    
+    LOG_FUNC_RETURN(card->ctx, r);
 }
 
 static int
@@ -5757,6 +5786,54 @@ err:
 	LOG_FUNC_RETURN(card->ctx, r);
 }
 
+/*
+ * Get the algorithm of the management key for admin operations.
+ */
+static u8 piv_get_management_key_algorithm(sc_card_t *card) {
+  int r;
+
+  sc_apdu_t apdu;
+  sc_format_apdu(card, &apdu,
+                 SC_APDU_CASE_2_SHORT, // command with output data only
+                 0xF7,                 // INS: GET METADATA Card Command
+                 0x00,                 // P1
+                 0x9B                  // P2
+  );
+
+  // The GET METADATA response for the management key slot consists of a list of
+  // TLVs. For the slot 0x9B, 4 tags are supported:
+  // 1. 0x01: Algorithm of the key
+  // 2. 0x02: PIN and touch policy
+  // 3. 0x03: Origin of the key
+  // 4. 0x05: Whether the management key has default value
+  //
+  // The response consists of 10 bytes:
+  //  - the algorithm TLV has 3 bytes (1 byte tag + 1 byte len + 1 byte length)
+  //  - the PIN and touch policy TLV has 4 bytes (1 byte tag + 1 byte len + 2
+  //  byte data)
+  //  - the origin TLV has 3 bytes (1 byte tag + 1 byte len + 1 byte data)
+  //  - the default TLV has 3 bytes (1 byte tag + 1 byte len + 1 byte data)
+  unsigned char rbuf[13];
+  apdu.resp = rbuf;
+  apdu.resplen = sizeof(rbuf);
+  apdu.le = sizeof(rbuf);
+
+  r = sc_transmit_apdu(card, &apdu);
+  LOG_TEST_RET(card->ctx, r, "Transmit GET METADATA APDU failed");
+
+  r = sc_check_sw(card, apdu.sw1, apdu.sw2);
+  LOG_TEST_RET(card->ctx, r, "GET METADATA command failed");
+
+  size_t algorithm_tag_len;
+  const u8 *algorithm;
+  algorithm = sc_asn1_find_tag(card->ctx, apdu.resp, apdu.resplen, 0x01,
+                               &algorithm_tag_len);
+  if (!algorithm || algorithm_tag_len != 1) {
+    sc_log(card->ctx, "Cannot get key management algorithm");
+    LOG_FUNC_RETURN(card->ctx, SC_ERROR_INVALID_ASN1_OBJECT);
+  }
+  return *algorithm;
+}
 
 static int piv_init(sc_card_t *card)
 {
@@ -5903,6 +5980,8 @@ static int piv_init(sc_card_t *card)
 	 * keys and certs. "piv like" cards may or may not have history
 	 */
 	piv_process_history(card);
+
+	priv->mgmt_key_alg = piv_get_management_key_algorithm(card);
 
 	priv->pstate=PIV_STATE_NORMAL;
 	sc_unlock(card);
@@ -6309,6 +6388,7 @@ static struct sc_card_driver * sc_get_driver(void)
 
 	piv_ops.select_file =  piv_select_file; /* must use get/put, could emulate? */
 	piv_ops.get_challenge = piv_get_challenge;
+	piv_ops.authenticate_challenge = piv_authenticate_challenge;
 	piv_ops.logout = piv_logout;
 	piv_ops.read_binary = piv_read_binary;
 	piv_ops.write_binary = piv_write_binary;

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -935,7 +935,7 @@ int sc_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-int sc_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len)
+int sc_authenticate_challenge(sc_card_t *card, const u8 *buf, size_t count)
 {
     int r;
 
@@ -951,7 +951,7 @@ int sc_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t r
     if (r != SC_SUCCESS)
         LOG_FUNC_RETURN(card->ctx, r);
 
-    r = card->ops->authenticate_challenge(card, response_data, response_data_len);
+    r = card->ops->authenticate_challenge(card, buf, count);
 
     sc_unlock(card);
 

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -935,6 +935,29 @@ int sc_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
+int sc_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len)
+{
+    int r;
+
+    if (card == NULL || response_data == NULL)
+        return SC_ERROR_INVALID_ARGUMENTS;
+
+    LOG_FUNC_CALLED(card->ctx);
+
+    if (card->ops == NULL || card->ops->authenticate_challenge == NULL)
+        LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+
+    r = sc_lock(card);
+    if (r != SC_SUCCESS)
+        LOG_FUNC_RETURN(card->ctx, r);
+
+    r = card->ops->authenticate_challenge(card, response_data, response_data_len);
+
+    sc_unlock(card);
+
+    LOG_FUNC_RETURN(card->ctx, r);
+}
+
 int sc_read_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,
 		   u8 *buf ,size_t count, unsigned long flags)
 {

--- a/src/libopensc/card.c
+++ b/src/libopensc/card.c
@@ -935,27 +935,29 @@ int sc_get_challenge(sc_card_t *card, u8 *rnd, size_t len)
 	LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 }
 
-int sc_authenticate_challenge(sc_card_t *card, const u8 *buf, size_t count)
+int
+sc_authenticate_challenge(
+		sc_card_t *card, const u8 *buf, size_t count)
 {
-    int r;
+	int r;
 
-    if (card == NULL || response_data == NULL)
-        return SC_ERROR_INVALID_ARGUMENTS;
+	if (card == NULL || buf == NULL)
+		return SC_ERROR_INVALID_ARGUMENTS;
 
-    LOG_FUNC_CALLED(card->ctx);
+	LOG_FUNC_CALLED(card->ctx);
 
-    if (card->ops == NULL || card->ops->authenticate_challenge == NULL)
-        LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
+	if (card->ops == NULL || card->ops->authenticate_challenge == NULL)
+		LOG_FUNC_RETURN(card->ctx, SC_ERROR_NOT_SUPPORTED);
 
-    r = sc_lock(card);
-    if (r != SC_SUCCESS)
-        LOG_FUNC_RETURN(card->ctx, r);
+	r = sc_lock(card);
+	if (r != SC_SUCCESS)
+		LOG_FUNC_RETURN(card->ctx, r);
 
-    r = card->ops->authenticate_challenge(card, buf, count);
+	r = card->ops->authenticate_challenge(card, buf, count);
 
-    sc_unlock(card);
+	sc_unlock(card);
 
-    LOG_FUNC_RETURN(card->ctx, r);
+	LOG_FUNC_RETURN(card->ctx, r);
 }
 
 int sc_read_record(sc_card_t *card, unsigned int rec_nr, unsigned int idx,

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1438,46 +1438,46 @@ no_match(struct sc_card *card)
 }
 
 static struct sc_card_operations iso_ops = {
-	no_match,
-	iso7816_init,	/* init   */
-	NULL,			/* finish */
-	iso7816_read_binary,
-	iso7816_write_binary,
-	iso7816_update_binary,
-	NULL,			/* erase_binary */
-	iso7816_read_record,
-	iso7816_write_record,
-	iso7816_append_record,
-	iso7816_update_record,
-	iso7816_select_file,
-	iso7816_get_response,
-	iso7816_get_challenge,
-	NULL,			/* authenticate_challenge*/
-	NULL,			/* verify */
-	NULL,			/* logout */
-	iso7816_restore_security_env,
-	iso7816_set_security_env,
-	iso7816_decipher,
-	iso7816_compute_signature,
-	NULL,			/* change_reference_data */
-	NULL,			/* reset_retry_counter   */
-	iso7816_create_file,
-	iso7816_delete_file,
-	NULL,			/* list_files */
-	iso7816_check_sw,
-	NULL,			/* card_ctl */
-	iso7816_process_fci,
-	iso7816_construct_fci,
-	iso7816_pin_cmd,
-	iso7816_get_data,
-	NULL,			/* put_data */
-	NULL,			/* delete_record */
-	NULL,			/* read_public_key */
-	NULL,			/* card_reader_lock_obtained */
-	NULL,			/* wrap */
-	NULL,			/* unwrap */
-	NULL,			/* encrypt_sym */
-	NULL			/* decrypt_sym */
+		no_match,
+		iso7816_init, /* init   */
+		NULL,	      /* finish */
+		iso7816_read_binary,
+		iso7816_write_binary,
+		iso7816_update_binary,
+		NULL, /* erase_binary */
+		iso7816_read_record,
+		iso7816_write_record,
+		iso7816_append_record,
+		iso7816_update_record,
+		iso7816_select_file,
+		iso7816_get_response,
+		iso7816_get_challenge,
+		NULL, /* authenticate_challenge*/
+		NULL, /* verify */
+		NULL, /* logout */
+		iso7816_restore_security_env,
+		iso7816_set_security_env,
+		iso7816_decipher,
+		iso7816_compute_signature,
+		NULL, /* change_reference_data */
+		NULL, /* reset_retry_counter   */
+		iso7816_create_file,
+		iso7816_delete_file,
+		NULL, /* list_files */
+		iso7816_check_sw,
+		NULL, /* card_ctl */
+		iso7816_process_fci,
+		iso7816_construct_fci,
+		iso7816_pin_cmd,
+		iso7816_get_data,
+		NULL, /* put_data */
+		NULL, /* delete_record */
+		NULL, /* read_public_key */
+		NULL, /* card_reader_lock_obtained */
+		NULL, /* wrap */
+		NULL, /* unwrap */
+		NULL, /* encrypt_sym */
+		NULL  /* decrypt_sym */
 };
 
 static struct sc_card_driver iso_driver = {

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1452,6 +1452,7 @@ static struct sc_card_operations iso_ops = {
 	iso7816_select_file,
 	iso7816_get_response,
 	iso7816_get_challenge,
+	NULL,           /* authenticate_challenge*/
 	NULL,			/* verify */
 	NULL,			/* logout */
 	iso7816_restore_security_env,

--- a/src/libopensc/iso7816.c
+++ b/src/libopensc/iso7816.c
@@ -1452,7 +1452,7 @@ static struct sc_card_operations iso_ops = {
 	iso7816_select_file,
 	iso7816_get_response,
 	iso7816_get_challenge,
-	NULL,           /* authenticate_challenge*/
+	NULL,			/* authenticate_challenge*/
 	NULL,			/* verify */
 	NULL,			/* logout */
 	iso7816_restore_security_env,

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -733,6 +733,18 @@ struct sc_card_operations {
 	 * @return number of random bytes successfully initialized (i.e. `count` or less bytes) or an error code
 	 */
 	int (*get_challenge)(struct sc_card *card, u8 * buf, size_t count);
+    
+	/**
+	 * @brief Authenticate a challenge
+	 *
+	 * Implementation of this call back is optional and may be NULL.
+	 *
+	 * @param  card   struct sc_card object on which to issue the command
+	 * @param  buf    buffer to be filled with calculated response
+	 * @param  count  number of bytes of calculated response
+	 * @return error code
+	 */
+	int (*authenticate_challenge)(struct sc_card *card, const u8 *response_data, size_t response_data_len);
 
 	/*
 	 * ISO 7816-8 functions
@@ -1364,6 +1376,8 @@ int sc_put_data(struct sc_card *, unsigned int, const u8 *, size_t);
  * @return SC_SUCCESS on success and an error code otherwise
  */
 int sc_get_challenge(struct sc_card *card, u8 * rndout, size_t len);
+
+int sc_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len);
 
 /********************************************************************/
 /*              ISO 7816-8 related functions                        */

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1377,7 +1377,8 @@ int sc_put_data(struct sc_card *, unsigned int, const u8 *, size_t);
  */
 int sc_get_challenge(struct sc_card *card, u8 * rndout, size_t len);
 
-int sc_authenticate_challenge(struct sc_card_t *card, const u8 *buf, size_t count);
+int sc_authenticate_challenge(struct sc_card *card, const u8 *buf, size_t count
+);
 
 /********************************************************************/
 /*              ISO 7816-8 related functions                        */

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -733,7 +733,7 @@ struct sc_card_operations {
 	 * @return number of random bytes successfully initialized (i.e. `count` or less bytes) or an error code
 	 */
 	int (*get_challenge)(struct sc_card *card, u8 * buf, size_t count);
-    
+
 	/**
 	 * @brief Authenticate a challenge
 	 *

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -740,11 +740,11 @@ struct sc_card_operations {
 	 * Implementation of this call back is optional and may be NULL.
 	 *
 	 * @param  card   struct sc_card object on which to issue the command
-	 * @param  buf    buffer to be filled with calculated response
-	 * @param  count  number of bytes of calculated response
-	 * @return error code
+	 * @param  buf    buffer with the response data
+	 * @param  count  number of response data bytes
+	 * @return SC_SUCCESS on success and an error code otherwise.
 	 */
-	int (*authenticate_challenge)(struct sc_card *card, const u8 *response_data, size_t response_data_len);
+	int (*authenticate_challenge)(struct sc_card *card, const u8 *buf, size_t count);
 
 	/*
 	 * ISO 7816-8 functions
@@ -1377,7 +1377,7 @@ int sc_put_data(struct sc_card *, unsigned int, const u8 *, size_t);
  */
 int sc_get_challenge(struct sc_card *card, u8 * rndout, size_t len);
 
-int sc_authenticate_challenge(sc_card_t *card, const u8 *response_data, size_t response_data_len);
+int sc_authenticate_challenge(struct sc_card_t *card, const u8 *buf, size_t count);
 
 /********************************************************************/
 /*              ISO 7816-8 related functions                        */

--- a/src/libopensc/opensc.h
+++ b/src/libopensc/opensc.h
@@ -1377,8 +1377,7 @@ int sc_put_data(struct sc_card *, unsigned int, const u8 *, size_t);
  */
 int sc_get_challenge(struct sc_card *card, u8 * rndout, size_t len);
 
-int sc_authenticate_challenge(struct sc_card *card, const u8 *buf, size_t count
-);
+int sc_authenticate_challenge(struct sc_card *card, const u8 *buf, size_t count);
 
 /********************************************************************/
 /*              ISO 7816-8 related functions                        */

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -5978,12 +5978,16 @@ DWORD WINAPI CardGetChallengeEx(__in PCARD_DATA pCardData,
 {
 	MD_FUNC_CALLED(pCardData, 1);
 
-	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
-		  (unsigned long)GetCurrentProcessId(),
-		  (unsigned long)GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardGetChallengeEx - unsupported\n");
+	if (!pCardData || !ppbChallengeData || !pcbChallengeData)
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
-	MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNSUPPORTED_FEATURE);
+	if (dwFlags != 0)
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
+
+	if (PinId != ROLE_ADMIN)
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
+
+	MD_FUNC_RETURN(pCardData, 1, CardGetChallenge(pCardData, ppbChallengeData, pcbChallengeData));
 }
 
 DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4200,6 +4200,7 @@ DWORD WINAPI CardDeauthenticate(__in PCARD_DATA pCardData,
 	DWORD dwret;
 	VENDOR_SPECIFIC* vs = NULL;
 	int rv;
+	struct sc_apdu apdu;
 
 	MD_FUNC_CALLED(pCardData, 1);
 
@@ -4224,13 +4225,12 @@ DWORD WINAPI CardDeauthenticate(__in PCARD_DATA pCardData,
 
 	sc_pkcs15_pincache_clear(vs->p15card);
 
-	rv = sc_logout(vs->p15card->card);
-
-	if (rv != SC_SUCCESS) {
-		/* force a reset of a card - SCARD_S_SUCCESS do not lead to the reset
-		 * of the card and leave it still authenticated */
-		dwret = SCARD_E_UNSUPPORTED_FEATURE;
-		goto err;
+	/* TODO: Use sc_logout() after OpenSC repository is synced with the official one */
+	/* Reset authentication state by sending APDU 00 20 FF 80 */
+	sc_format_apdu(vs->p15card->card, &apdu, SC_APDU_CASE_1, 0x20, 0xFF, 0x80);
+	rv = sc_transmit_apdu(vs->p15card->card, &apdu);
+	if (rv < 0) {
+		logprintf(pCardData, 1, "Failed to reset auth state: %s\n", sc_strerror(rv));
 	}
 
 	dwret = SCARD_S_SUCCESS;

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7024,17 +7024,17 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
 	if (!(dwFlags & CARD_SECURE_KEY_INJECTION_NO_CARD_MODE)) {
-		if( pCardData->hSCardCtx == 0)   {
+		if (pCardData->hSCardCtx == 0) {
 			logprintf(pCardData, 0, "Invalid handle.\n");
 			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
 		}
-		if( pCardData->hScard == 0)   {
+		if (pCardData->hScard == 0) {
 			logprintf(pCardData, 0, "Invalid handle.\n");
 			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
 		}
-	}
-	else
-	{
+	} else {
+		if (pCardData->dwVersion < CARD_DATA_VERSION_SEVEN)
+			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 		/* secure key injection not supported */
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNSUPPORTED_FEATURE);
 	}
@@ -7043,12 +7043,15 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	if ( pCardData->pwszCardName == NULL )
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
-	/* <2 length or >0x22 are not ISO compliant */
-	if (pCardData->cbAtr > 0x22 || pCardData->cbAtr < 0x2)
+	/* <2 length or >33 are not ISO compliant */
+	if (pCardData->cbAtr > 0x21 || pCardData->cbAtr < 0x2)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	/* ATR beginning by 0x00 or 0xFF are not ISO compliant */
 	if (pCardData->pbAtr[0] == 0xFF || pCardData->pbAtr[0] == 0x00)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
+	/* 2 bytes ATR is not a known card to microsoft minidriver*/
+	if (pCardData->cbAtr == 2)
+	    MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
 	/* Memory management functions */
 	if ( ( pCardData->pfnCspAlloc   == NULL ) ||
 		( pCardData->pfnCspReAlloc == NULL ) ||

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3922,8 +3922,8 @@ DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
 	MD_FUNC_CALLED(pCardData, 1);
 
 	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
-			(unsigned long)GetCurrentProcessId(),
-			(unsigned long)GetCurrentThreadId(), pCardData);
+		  (unsigned long)GetCurrentProcessId(),
+		  (unsigned long)GetCurrentThreadId(), pCardData);
 	logprintf(pCardData, 1, "CardAuthenticateChallenge\n");
 
 	if (!pCardData || !pbResponseData || !lock(pCardData))

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3917,11 +3917,7 @@ DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
 {
     VENDOR_SPECIFIC *vs;
     DWORD dwret;
-    int rv, tmplen;
-    struct sc_apdu apdu;
-    PBYTE output_buf = NULL;
-    PBYTE p = NULL;
-    size_t output_len = 0;
+    int rv;
 
     MD_FUNC_CALLED(pCardData, 1);
 
@@ -3948,103 +3944,23 @@ DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
     if (pcAttemptsRemaining)
         *pcAttemptsRemaining = (DWORD)-1;
 
-    /*
-     * Build: 7C<len>[82<len><challenge>]
-     * Start off by capturing the data of the response:
-     *     - 82<len><encrypted challenege response>
-     * Build the outside TLV (7C)
-     * Advance past that tag + len
-     * Build the body (82)
-     * memcopy the body past the 7C<len> portion
-     * Transmit
-     */
-
-    // Calculate the size needed for the output buffer
-    // First, get the size of the inner TLV (0x82 tag)
-    tmplen = sc_asn1_put_tag(0x82, NULL, cbResponseData, NULL, 0, NULL);
-    if (tmplen <= 0) {
-        logprintf(pCardData, 1, "Failed to calculate inner TLV size\n");
-        dwret = SCARD_E_UNEXPECTED;
-        goto err;
-    }
-
-    // Then calculate the total size including the outer TLV (0x7C tag)
-    output_len = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL);
-    if (output_len <= 0) {
-        logprintf(pCardData, 1, "Failed to calculate outer TLV size\n");
-        dwret = SCARD_E_UNEXPECTED;
-        goto err;
-    }
-
-    // Allocate buffer for the formatted data
-    output_buf = pCardData->pfnCspAlloc(output_len);
-    if (!output_buf) {
-        logprintf(pCardData, 1, "Out of memory\n");
-        dwret = SCARD_E_NO_MEMORY;
-        goto err;
-    }
-
-    // Build the outer TLV (7C)
-    p = output_buf;
-    rv = sc_asn1_put_tag(0x7C, NULL, tmplen, p, output_len, &p);
-    if (rv != SC_SUCCESS) {
-        logprintf(pCardData, 1, "Failed to build outer TLV: %s\n", sc_strerror(rv));
-        dwret = SCARD_E_UNEXPECTED;
-        goto err;
-    }
-
-    // Build the inner TLV (82) and append to the 7C<len> tag
-    rv = sc_asn1_put_tag(0x82, pbResponseData, cbResponseData, p, output_len - (p - output_buf), &p);
-    if (rv != SC_SUCCESS) {
-        logprintf(pCardData, 1, "Failed to build inner TLV: %s\n", sc_strerror(rv));
-        dwret = SCARD_E_UNEXPECTED;
-        goto err;
-    }
-
-    // Prepare the APDU for authentication
-    // For PIV cards, this is GENERAL AUTHENTICATE command
-    // CLA: 0x00, INS: 0x87 (GENERAL AUTHENTICATE), P1: 0x00 (algorithm), P2: 0x9B (key reference)
-    sc_format_apdu(vs->card, &apdu, SC_APDU_CASE_3_SHORT, 0x87, 0x00, 0x9B);
-    apdu.lc = output_len;
-    apdu.data = output_buf;
-    apdu.datalen = output_len;
-    apdu.resp = NULL;
-    apdu.resplen = 0;
+    rv = sc_authenticate_challenge(vs->card, pbResponseData, cbResponseData);
     
-    logprintf(pCardData, 3, "Sending authentication APDU to card\n");
-    loghex(pCardData, 7, output_buf, output_len);
-    
-    rv = sc_transmit_apdu(vs->card, &apdu);
-    
-    if (rv != SC_SUCCESS) {
-        logprintf(pCardData, 1, "APDU transmit failed: %s\n", sc_strerror(rv));
-        dwret = md_translate_OpenSC_to_Windows_error(rv, SCARD_E_UNEXPECTED);
-        goto err;
-    }
-    
-    // Check the response status
-    rv = sc_check_sw(vs->card, apdu.sw1, apdu.sw2);
-   
     if (rv != SC_SUCCESS) {
         logprintf(pCardData, 1, "Challenge-response authentication failed: %s\n", sc_strerror(rv));
         
-        if (rv == SC_ERROR_AUTH_METHOD_BLOCKED) {
+        dwret = md_translate_OpenSC_to_Windows_error(rv, SCARD_E_UNEXPECTED);
+        if (rv == SC_ERROR_AUTH_METHOD_BLOCKED)
             dwret = SCARD_W_CHV_BLOCKED;
-        } else {
+        else if (rv == SC_ERROR_PIN_CODE_INCORRECT)
             dwret = SCARD_W_WRONG_CHV;
-        }
-       
         goto err;
     }
 
-    // Authentication successful
     logprintf(pCardData, 1, "Challenge-response authentication successful\n");
-    
     dwret = SCARD_S_SUCCESS;
 
 err:
-    if (output_buf)
-        pCardData->pfnCspFree(output_buf);
     unlock(pCardData);
     MD_FUNC_RETURN(pCardData, 1, dwret);
 }

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7051,7 +7051,7 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
 	/* 2 bytes ATR is not a known card to microsoft minidriver*/
 	if (pCardData->cbAtr == 2)
-	    MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
 	/* Memory management functions */
 	if ( ( pCardData->pfnCspAlloc   == NULL ) ||
 		( pCardData->pfnCspReAlloc == NULL ) ||

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * minidriver.c: OpenSC minidriver
  *
  * Copyright (C) 2009,2010 francois.leblanc@cev-sa.com
@@ -6025,6 +6025,8 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 		  "CardAuthenticateEx: PinId=%u, dwFlags=0x%08X, cbPinData=%lu, Attempts %s\n",
 		  (unsigned int)PinId, (unsigned int)dwFlags,
 		  (unsigned long)cbPinData, pcAttemptsRemaining ? "YES" : "NO");
+	logprintf(pCardData, 1, "pbPinData:");
+	loghex(pCardData, 2, pbPinData, cbPinData);
 
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	if (!vs)
@@ -6072,6 +6074,7 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 	auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
 	/* save the pin type */
 	auth_method = auth_info->auth_method;
+	logprintf(pCardData, 1, "auth_info->auth_method: %d\n", auth_info->auth_method);
 
 	/* Do we need to display a prompt to enter PIN on pin pad? */
 	logprintf(pCardData, 7, "PIN pad=%s, pbPinData=%p, hwndParent=%p\n",
@@ -6146,7 +6149,17 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 					(unsigned long) cbPinData, (unsigned int) auth_info->auth_method, (unsigned char) auth_info->auth_id.value[0]);
 			auth_info->auth_method = SC_AC_CONTEXT_SPECIFIC;
 		}
-		r = md_dialog_perform_pin_operation(pCardData, SC_PIN_CMD_VERIFY, vs->p15card, pin_obj, (const u8 *) pbPinData, cbPinData, NULL, NULL, DisplayPinpadUI, PinId);
+		if (PinId == ROLE_ADMIN) {
+			u8 auth_data[3];
+			auth_data[0] = 'A';
+			auth_data[1] = 0x9B;
+			auth_data[2] = 0x00;
+			r = sc_card_ctl(vs->p15card->card, SC_CARDCTL_PIV_AUTHENTICATE, auth_data);
+		}
+		else {
+			r = md_dialog_perform_pin_operation(pCardData, SC_PIN_CMD_VERIFY, vs->p15card, pin_obj, (const u8 *) pbPinData, cbPinData, NULL, NULL, DisplayPinpadUI, PinId);
+		}
+
 	}
 
 	/* restore the pin type */

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3910,19 +3910,146 @@ err:
 }
 
 
-DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
-	__in_bcount(cbResponseData) PBYTE  pbResponseData,
-	__in DWORD  cbResponseData,
-	__out_opt PDWORD pcAttemptsRemaining)
+DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA pCardData,
+    __in_bcount(cbResponseData) PBYTE pbResponseData,
+    __in DWORD cbResponseData,
+    __out_opt PDWORD pcAttemptsRemaining)
 {
-	MD_FUNC_CALLED(pCardData, 1);
+    VENDOR_SPECIFIC *vs;
+    DWORD dwret;
+    int rv, tmplen;
+    struct sc_apdu apdu;
+    PBYTE output_buf = NULL;
+    PBYTE p = NULL;
+    size_t output_len = 0;
 
-	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
-		  (unsigned long)GetCurrentProcessId(),
-		  (unsigned long)GetCurrentThreadId(), pCardData);
-	logprintf(pCardData, 1, "CardAuthenticateChallenge - unsupported\n");
+    MD_FUNC_CALLED(pCardData, 1);
 
-	MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNSUPPORTED_FEATURE);
+    logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+        (unsigned long)GetCurrentProcessId(),
+        (unsigned long)GetCurrentThreadId(), pCardData);
+    logprintf(pCardData, 1, "CardAuthenticateChallenge\n");
+
+    if (!pCardData || !pbResponseData || !lock(pCardData))
+        MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
+
+    dwret = check_card_reader_status(pCardData, "CardAuthenticateChallenge");
+    if (dwret != SCARD_S_SUCCESS)
+        goto err;
+
+    vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
+    if (!vs) {
+        dwret = SCARD_E_INVALID_PARAMETER;
+        goto err;
+    }
+
+    // Set attempts remaining to -1 (unknown) as per documentation
+    // because piv management key does not have attempts remaining
+    if (pcAttemptsRemaining)
+        *pcAttemptsRemaining = (DWORD)-1;
+
+    logprintf(pCardData, 7, "Response from client: ");
+    loghex(pCardData, 7, pbResponseData, cbResponseData);
+
+    /*
+     * Build: 7C<len>[82<len><challenge>]
+     * Start off by capturing the data of the response:
+     *     - 82<len><encrypted challenege response>
+     * Build the outside TLV (7C)
+     * Advance past that tag + len
+     * Build the body (82)
+     * memcopy the body past the 7C<len> portion
+     * Transmit
+     */
+
+    // Calculate the size needed for the output buffer
+    // First, get the size of the inner TLV (0x82 tag)
+    tmplen = sc_asn1_put_tag(0x82, NULL, cbResponseData, NULL, 0, NULL);
+    if (tmplen <= 0) {
+        logprintf(pCardData, 1, "Failed to calculate inner TLV size\n");
+        dwret = SCARD_E_UNEXPECTED;
+        goto err;
+    }
+
+    // Then calculate the total size including the outer TLV (0x7C tag)
+    output_len = sc_asn1_put_tag(0x7C, NULL, tmplen, NULL, 0, NULL);
+    if (output_len <= 0) {
+        logprintf(pCardData, 1, "Failed to calculate outer TLV size\n");
+        dwret = SCARD_E_UNEXPECTED;
+        goto err;
+    }
+
+    // Allocate buffer for the formatted data
+    output_buf = pCardData->pfnCspAlloc(output_len);
+    if (!output_buf) {
+        logprintf(pCardData, 1, "Out of memory\n");
+        dwret = SCARD_E_NO_MEMORY;
+        goto err;
+    }
+
+    // Build the outer TLV (7C)
+    p = output_buf;
+    rv = sc_asn1_put_tag(0x7C, NULL, tmplen, p, output_len, &p);
+    if (rv != SC_SUCCESS) {
+        logprintf(pCardData, 1, "Failed to build outer TLV: %s\n", sc_strerror(rv));
+        dwret = SCARD_E_UNEXPECTED;
+        goto err;
+    }
+
+    // Build the inner TLV (82) and append to the 7C<len> tag
+    rv = sc_asn1_put_tag(0x82, pbResponseData, cbResponseData, p, output_len - (p - output_buf), &p);
+    if (rv != SC_SUCCESS) {
+        logprintf(pCardData, 1, "Failed to build inner TLV: %s\n", sc_strerror(rv));
+        dwret = SCARD_E_UNEXPECTED;
+        goto err;
+    }
+
+    // Prepare the APDU for authentication
+    // For PIV cards, this is GENERAL AUTHENTICATE command
+    // CLA: 0x00, INS: 0x87 (GENERAL AUTHENTICATE), P1: 0x00 (algorithm), P2: 0x9B (key reference)
+    sc_format_apdu(vs->card, &apdu, SC_APDU_CASE_3_SHORT, 0x87, 0x00, 0x9B);
+    apdu.lc = output_len;
+    apdu.data = output_buf;
+    apdu.datalen = output_len;
+    apdu.resp = NULL;
+    apdu.resplen = 0;
+    
+    logprintf(pCardData, 3, "Sending authentication APDU to card\n");
+    loghex(pCardData, 7, output_buf, output_len);
+    
+    rv = sc_transmit_apdu(vs->card, &apdu);
+    
+    if (rv != SC_SUCCESS) {
+        logprintf(pCardData, 1, "APDU transmit failed: %s\n", sc_strerror(rv));
+        dwret = md_translate_OpenSC_to_Windows_error(rv, SCARD_E_UNEXPECTED);
+        goto err;
+    }
+    
+    // Check the response status
+    rv = sc_check_sw(vs->card, apdu.sw1, apdu.sw2);
+   
+    if (rv != SC_SUCCESS) {
+        logprintf(pCardData, 1, "Challenge-response authentication failed: %s\n", sc_strerror(rv));
+        
+        if (rv == SC_ERROR_AUTH_METHOD_BLOCKED) {
+            dwret = SCARD_W_CHV_BLOCKED;
+        } else {
+            dwret = SCARD_W_WRONG_CHV;
+        }
+       
+        goto err;
+    }
+
+    // Authentication successful
+    logprintf(pCardData, 1, "Challenge-response authentication successful\n");
+    
+    dwret = SCARD_S_SUCCESS;
+
+err:
+    if (output_buf)
+        pCardData->pfnCspFree(output_buf);
+    unlock(pCardData);
+    MD_FUNC_RETURN(pCardData, 1, dwret);
 }
 
 
@@ -6458,9 +6585,18 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 		if (dwFlags != ROLE_EVERYONE && vs->pin_objs[dwFlags] == NULL)
 			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
-		p->PinType = vs->reader->capabilities & SC_READER_CAP_PIN_PAD
-			|| vs->p15card->card->caps & SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH
-			? ExternalPinType : AlphaNumericPinType;
+		if (dwFlags == ROLE_ADMIN && pCardData->dwVersion >= CARD_DATA_VERSION_SIX)
+		{
+			// For admin PIN in V6 and above, use ChallengeResponsePinType
+			p->PinType = ChallengeResponsePinType;
+		}
+		else
+		{
+			// For other PINs or older versions, use the original logic
+			p->PinType = vs->reader->capabilities & SC_READER_CAP_PIN_PAD || vs->p15card->card->caps & SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH
+							 ? ExternalPinType
+							 : AlphaNumericPinType;
+		}
 		p->dwFlags = 0;
 		switch (dwFlags)   {
 			case ROLE_EVERYONE:

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -6502,17 +6502,14 @@ DWORD WINAPI CardGetProperty(__in PCARD_DATA pCardData,
 		if (dwFlags != ROLE_EVERYONE && vs->pin_objs[dwFlags] == NULL)
 			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
-		if (dwFlags == ROLE_ADMIN && pCardData->dwVersion >= CARD_DATA_VERSION_SIX)
-		{
+		if (dwFlags == ROLE_ADMIN && pCardData->dwVersion >= CARD_DATA_VERSION_SIX) {
 			// For admin PIN in V6 and above, use ChallengeResponsePinType
 			p->PinType = ChallengeResponsePinType;
-		}
-		else
-		{
+		} else {
 			// For other PINs or older versions, use the original logic
 			p->PinType = vs->reader->capabilities & SC_READER_CAP_PIN_PAD || vs->p15card->card->caps & SC_CARD_CAP_PROTECTED_AUTHENTICATION_PATH
-							 ? ExternalPinType
-							 : AlphaNumericPinType;
+						     ? ExternalPinType
+						     : AlphaNumericPinType;
 		}
 		p->dwFlags = 0;
 		switch (dwFlags)   {

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3915,56 +3915,50 @@ DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
 	__in DWORD  cbResponseData,
 	__out_opt PDWORD pcAttemptsRemaining)
 {
-    VENDOR_SPECIFIC *vs;
-    DWORD dwret;
-    int rv;
+	VENDOR_SPECIFIC *vs;
+	DWORD dwret;
+	int rv;
 
-    MD_FUNC_CALLED(pCardData, 1);
+	MD_FUNC_CALLED(pCardData, 1);
 
-    logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
-        (unsigned long)GetCurrentProcessId(),
-        (unsigned long)GetCurrentThreadId(), pCardData);
-    logprintf(pCardData, 1, "CardAuthenticateChallenge\n");
+	logprintf(pCardData, 1, "\nP:%lu T:%lu pCardData:%p ",
+			(unsigned long)GetCurrentProcessId(),
+			(unsigned long)GetCurrentThreadId(), pCardData);
+	logprintf(pCardData, 1, "CardAuthenticateChallenge\n");
 
-    if (!pCardData || !pbResponseData || !lock(pCardData))
-        MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
+	if (!pCardData || !pbResponseData || !lock(pCardData))
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
-    dwret = check_card_reader_status(pCardData, "CardAuthenticateChallenge");
-    if (dwret != SCARD_S_SUCCESS)
-        goto err;
+	dwret = check_card_reader_status(pCardData, "CardAuthenticateChallenge");
+	if (dwret != SCARD_S_SUCCESS)
+		goto err;
 
-    vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
-    if (!vs) {
-        dwret = SCARD_E_INVALID_PARAMETER;
-        goto err;
-    }
+	vs = (VENDOR_SPECIFIC *)(pCardData->pvVendorSpecific);
+	if (!vs) {
+		dwret = SCARD_E_INVALID_PARAMETER;
+		goto err;
+	}
 
-    // Set attempts remaining to -1 (unknown) as per documentation
-    // because piv management key does not have attempts remaining
-    if (pcAttemptsRemaining)
-        *pcAttemptsRemaining = (DWORD)-1;
+	// Set attempts remaining to -1 (unknown) as per documentation
+	// because piv management key does not have attempts remaining
+	if (pcAttemptsRemaining)
+		*pcAttemptsRemaining = (DWORD)-1;
 
-    rv = sc_authenticate_challenge(vs->card, pbResponseData, cbResponseData);
-    
-    if (rv != SC_SUCCESS) {
-        logprintf(pCardData, 1, "Challenge-response authentication failed: %s\n", sc_strerror(rv));
-        
-        dwret = md_translate_OpenSC_to_Windows_error(rv, SCARD_E_UNEXPECTED);
-        if (rv == SC_ERROR_AUTH_METHOD_BLOCKED)
-            dwret = SCARD_W_CHV_BLOCKED;
-        else if (rv == SC_ERROR_PIN_CODE_INCORRECT)
-            dwret = SCARD_W_WRONG_CHV;
-        goto err;
-    }
+	rv = sc_authenticate_challenge(vs->card, pbResponseData, cbResponseData);
 
-    logprintf(pCardData, 1, "Challenge-response authentication successful\n");
-    dwret = SCARD_S_SUCCESS;
+	if (rv != SC_SUCCESS) {
+		logprintf(pCardData, 1, "Challenge-response authentication failed: %s\n", sc_strerror(rv));
+
+		dwret = md_translate_OpenSC_to_Windows_error(rv, SCARD_E_UNEXPECTED);
+		goto err;
+	}
+
+	dwret = SCARD_S_SUCCESS;
 
 err:
-    unlock(pCardData);
-    MD_FUNC_RETURN(pCardData, 1, dwret);
+	unlock(pCardData);
+	MD_FUNC_RETURN(pCardData, 1, dwret);
 }
-
 
 DWORD WINAPI CardUnblockPin(__in PCARD_DATA  pCardData,
 	__in LPWSTR pwszUserId,

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -3910,10 +3910,10 @@ err:
 }
 
 
-DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA pCardData,
-    __in_bcount(cbResponseData) PBYTE pbResponseData,
-    __in DWORD cbResponseData,
-    __out_opt PDWORD pcAttemptsRemaining)
+DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA  pCardData,
+	__in_bcount(cbResponseData) PBYTE  pbResponseData,
+	__in DWORD  cbResponseData,
+	__out_opt PDWORD pcAttemptsRemaining)
 {
     VENDOR_SPECIFIC *vs;
     DWORD dwret;
@@ -3947,9 +3947,6 @@ DWORD WINAPI CardAuthenticateChallenge(__in PCARD_DATA pCardData,
     // because piv management key does not have attempts remaining
     if (pcAttemptsRemaining)
         *pcAttemptsRemaining = (DWORD)-1;
-
-    logprintf(pCardData, 7, "Response from client: ");
-    loghex(pCardData, 7, pbResponseData, cbResponseData);
 
     /*
      * Build: 7C<len>[82<len><challenge>]
@@ -4200,7 +4197,6 @@ DWORD WINAPI CardDeauthenticate(__in PCARD_DATA pCardData,
 	DWORD dwret;
 	VENDOR_SPECIFIC* vs = NULL;
 	int rv;
-	struct sc_apdu apdu;
 
 	MD_FUNC_CALLED(pCardData, 1);
 
@@ -4225,12 +4221,13 @@ DWORD WINAPI CardDeauthenticate(__in PCARD_DATA pCardData,
 
 	sc_pkcs15_pincache_clear(vs->p15card);
 
-	/* TODO: Use sc_logout() after OpenSC repository is synced with the official one */
-	/* Reset authentication state by sending APDU 00 20 FF 80 */
-	sc_format_apdu(vs->p15card->card, &apdu, SC_APDU_CASE_1, 0x20, 0xFF, 0x80);
-	rv = sc_transmit_apdu(vs->p15card->card, &apdu);
-	if (rv < 0) {
-		logprintf(pCardData, 1, "Failed to reset auth state: %s\n", sc_strerror(rv));
+	rv = sc_logout(vs->p15card->card);
+
+	if (rv != SC_SUCCESS) {
+		/* force a reset of a card - SCARD_S_SUCCESS do not lead to the reset
+		 * of the card and leave it still authenticated */
+		dwret = SCARD_E_UNSUPPORTED_FEATURE;
+		goto err;
 	}
 
 	dwret = SCARD_S_SUCCESS;
@@ -6025,8 +6022,6 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 		  "CardAuthenticateEx: PinId=%u, dwFlags=0x%08X, cbPinData=%lu, Attempts %s\n",
 		  (unsigned int)PinId, (unsigned int)dwFlags,
 		  (unsigned long)cbPinData, pcAttemptsRemaining ? "YES" : "NO");
-	logprintf(pCardData, 1, "pbPinData:");
-	loghex(pCardData, 2, pbPinData, cbPinData);
 
 	vs = (VENDOR_SPECIFIC*)(pCardData->pvVendorSpecific);
 	if (!vs)
@@ -6074,7 +6069,6 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 	auth_info = (struct sc_pkcs15_auth_info *)pin_obj->data;
 	/* save the pin type */
 	auth_method = auth_info->auth_method;
-	logprintf(pCardData, 1, "auth_info->auth_method: %d\n", auth_info->auth_method);
 
 	/* Do we need to display a prompt to enter PIN on pin pad? */
 	logprintf(pCardData, 7, "PIN pad=%s, pbPinData=%p, hwndParent=%p\n",
@@ -6138,28 +6132,24 @@ DWORD WINAPI CardAuthenticateEx(__in PCARD_DATA pCardData,
 	} else {
 		if (pcbSessionPin) *pcbSessionPin = 0;
 		if (ppbSessionPin) *ppbSessionPin = NULL;
-		logprintf(pCardData, 2, "standard pin verification");
-		/*
-		 * TODO the use of auth_method being overridden to do session pin
-		 * conflicts with framework-pkcs15.c use of auth_method  SC_AC_CONTEXT_SPECIFIC
-		 * for a different purpose. But needs to be reviewed
-		 */
-		if (PinId == MD_ROLE_USER_SIGN && vs->need_pin_always) {
-			logprintf(pCardData, 7, "Setting SC_AC_CONTEXT_SPECIFIC cbPinData: %lu old auth_method: %0x auth_id:%x \n",
-					(unsigned long) cbPinData, (unsigned int) auth_info->auth_method, (unsigned char) auth_info->auth_id.value[0]);
-			auth_info->auth_method = SC_AC_CONTEXT_SPECIFIC;
-		}
-		if (PinId == ROLE_ADMIN) {
-			u8 auth_data[3];
-			auth_data[0] = 'A';
-			auth_data[1] = 0x9B;
-			auth_data[2] = 0x00;
-			r = sc_card_ctl(vs->p15card->card, SC_CARDCTL_PIV_AUTHENTICATE, auth_data);
-		}
-		else {
-			r = md_dialog_perform_pin_operation(pCardData, SC_PIN_CMD_VERIFY, vs->p15card, pin_obj, (const u8 *) pbPinData, cbPinData, NULL, NULL, DisplayPinpadUI, PinId);
-		}
 
+		if (PinId == ROLE_ADMIN) {
+			logprintf(pCardData, 2, "challenge response pin verification");
+			MD_FUNC_RETURN(pCardData, 1, CardAuthenticateChallenge(pCardData, pbPinData, cbPinData, pcAttemptsRemaining));
+		} else {
+			logprintf(pCardData, 2, "standard pin verification");
+			/*
+			 * TODO the use of auth_method being overridden to do session pin
+			 * conflicts with framework-pkcs15.c use of auth_method  SC_AC_CONTEXT_SPECIFIC
+			 * for a different purpose. But needs to be reviewed
+			 */
+			if (PinId == MD_ROLE_USER_SIGN && vs->need_pin_always) {
+				logprintf(pCardData, 7, "Setting SC_AC_CONTEXT_SPECIFIC cbPinData: %lu old auth_method: %0x auth_id:%x \n",
+						(unsigned long)cbPinData, (unsigned int)auth_info->auth_method, (unsigned char)auth_info->auth_id.value[0]);
+				auth_info->auth_method = SC_AC_CONTEXT_SPECIFIC;
+			}
+			r = md_dialog_perform_pin_operation(pCardData, SC_PIN_CMD_VERIFY, vs->p15card, pin_obj, (const u8 *)pbPinData, cbPinData, NULL, NULL, DisplayPinpadUI, PinId);
+		}
 	}
 
 	/* restore the pin type */


### PR DESCRIPTION
implemented:
- [x] CardAuthenticateChallenge
- [x] CardGetChallengeEx
- [x] CardAuthenticateEx for PinId is 2, which uses challenge response mechanism with management key
- [x] Adjust the pin type for V6 and above for PinId is 2(ROLE_ADMIN)

With these changes makes iShieldKey pass the SanityTest in HLK smart card minidriver.