### PR TITLE
fix cardacquirecontext test

### DIFF
--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7029,16 +7029,23 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 
 	MD_FUNC_CALLED(pCardData, 1);
 
-	if (dwFlags != 0)
+	if (dwFlags & ~CARD_SECURE_KEY_INJECTION_NO_CARD_MODE)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
-	if(pCardData->hSCardCtx == 0)   {
-		logprintf(pCardData, 0, "Invalid handle.\n");
-		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
-	}
-	if(pCardData->hScard == 0)   {
-		logprintf(pCardData, 0, "Invalid handle.\n");
-		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
+	if (!(dwFlags & CARD_SECURE_KEY_INJECTION_NO_CARD_MODE)) {
+		if (pCardData->hSCardCtx == 0) {
+			logprintf(pCardData, 0, "Invalid handle.\n");
+			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
+		}
+		if (pCardData->hScard == 0) {
+			logprintf(pCardData, 0, "Invalid handle.\n");
+			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
+		}
+	} else {
+		if (pCardData->dwVersion < CARD_DATA_VERSION_SEVEN)
+			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
+		/* secure key injection not supported */
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNSUPPORTED_FEATURE);
 	}
 
 	if (pCardData->pbAtr == NULL)

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -7029,35 +7029,31 @@ DWORD WINAPI CardAcquireContext(__inout PCARD_DATA pCardData, __in DWORD dwFlags
 
 	MD_FUNC_CALLED(pCardData, 1);
 
-	if (dwFlags & ~CARD_SECURE_KEY_INJECTION_NO_CARD_MODE)
+	if (dwFlags != 0)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 
-	if (!(dwFlags & CARD_SECURE_KEY_INJECTION_NO_CARD_MODE)) {
-		if( pCardData->hSCardCtx == 0)   {
-			logprintf(pCardData, 0, "Invalid handle.\n");
-			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
-		}
-		if( pCardData->hScard == 0)   {
-			logprintf(pCardData, 0, "Invalid handle.\n");
-			MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
-		}
+	if(pCardData->hSCardCtx == 0)   {
+		logprintf(pCardData, 0, "Invalid handle.\n");
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
 	}
-	else
-	{
-		/* secure key injection not supported */
-		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNSUPPORTED_FEATURE);
+	if(pCardData->hScard == 0)   {
+		logprintf(pCardData, 0, "Invalid handle.\n");
+		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_HANDLE);
 	}
 
 	if (pCardData->pbAtr == NULL)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	if ( pCardData->pwszCardName == NULL )
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
-	/* <2 length or >0x22 are not ISO compliant */
-	if (pCardData->cbAtr > 0x22 || pCardData->cbAtr < 0x2)
+	/* <2 length or >33 are not ISO compliant */
+	if (pCardData->cbAtr > 0x21 || pCardData->cbAtr < 0x2)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_INVALID_PARAMETER);
 	/* ATR beginning by 0x00 or 0xFF are not ISO compliant */
 	if (pCardData->pbAtr[0] == 0xFF || pCardData->pbAtr[0] == 0x00)
 		MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
+	/* 2 bytes ATR is not a known card to microsoft minidriver*/
+	if (pCardData->cbAtr == 2)
+	    MD_FUNC_RETURN(pCardData, 1, SCARD_E_UNKNOWN_CARD);
 	/* Memory management functions */
 	if ( ( pCardData->pfnCspAlloc   == NULL ) ||
 		( pCardData->pfnCspReAlloc == NULL ) ||


### PR DESCRIPTION
- [x] return SCARD_E_INVALID_PARAMETER when dwFlags is not 0, as test expected
- [x] fix ATR length check, which should be from 2 to 33
- [x] when ATR length is valid, but the ATR length is not a known length by microsoft minidriver, it should return SCARD_E_UNKNOWN_CARD