### PR TITLE
bump opensc version and minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ doc/tools/opensc-notify
 doc/files/opensc.conf.5.xml
 doc/files/pkcs15-profile.5.xml
 
+etc/opensc.conf
 etc/opensc.conf.example
 src/common/compat_getopt_main
 src/minidriver/opensc-minidriver.inf

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ define([PRODUCT_URL], [https://github.com/OpenSC/OpenSC])
 define([PACKAGE_VERSION_MAJOR], [0])
 define([PACKAGE_VERSION_MINOR], [26])
 define([PACKAGE_VERSION_FIX], [1])
-define([PACKAGE_SUFFIX], [-swissbit-piv-beta])
+define([PACKAGE_SUFFIX], [-swissbit-piv])
 
 define([VS_FF_LEGAL_COPYRIGHT], [OpenSC Project])
 define([VS_FF_LEGAL_COMPANY_NAME], [OpenSC Project])
@@ -998,6 +998,15 @@ if test "${enable_sm}" = "yes"; then
 	esac
 fi
 
+case "${host}" in
+	*x86*)
+		DEFAULT_INSTALL_DIR="C:\\Program Files (x86)\\OpenSC Project\\OpenSC\\"
+	;;
+	*)
+		DEFAULT_INSTALL_DIR="C:\\Program Files\\OpenSC Project\\OpenSC\\"
+	;;
+esac
+
 if test "${with_pkcs11_provider}" = "detect"; then
 	if test "${WIN32}" != "yes"; then
 		DEFAULT_PKCS11_PROVIDER="${libdir}/opensc-pkcs11${DYN_LIB_EXT}"
@@ -1136,6 +1145,7 @@ AC_SUBST([OPTIONAL_PCSC_CFLAGS])
 AC_SUBST([LIBRARY_BITNESS])
 AC_SUBST([DEFAULT_SM_MODULE])
 AC_SUBST([DEFAULT_SM_MODULE_PATH])
+AC_SUBST([DEFAULT_INSTALL_DIR])
 AC_SUBST([DEBUG_FILE])
 AC_SUBST([PROFILE_DIR])
 AC_SUBST([PROFILE_DIR_DEFAULT])
@@ -1184,6 +1194,7 @@ AC_CONFIG_FILES([
 	doc/tools/Makefile
 	doc/files/Makefile
 	etc/Makefile
+	etc/opensc.conf
 	tests/Makefile
 	src/Makefile
 	src/common/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -998,14 +998,11 @@ if test "${enable_sm}" = "yes"; then
 	esac
 fi
 
-case "${host}" in
-	*x86*)
-		DEFAULT_INSTALL_DIR="C:\\Program Files (x86)\\OpenSC Project\\OpenSC\\"
-	;;
-	*)
-		DEFAULT_INSTALL_DIR="C:\\Program Files\\OpenSC Project\\OpenSC\\"
-	;;
-esac
+if test "${PLATFORM}" = "x86"; then
+	DEFAULT_INSTALL_DIR="C:\\Program Files (x86)\\OpenSC Project\\OpenSC\\"
+else
+	DEFAULT_INSTALL_DIR="C:\\Program Files\\OpenSC Project\\OpenSC\\"
+fi
 
 if test "${with_pkcs11_provider}" = "detect"; then
 	if test "${WIN32}" != "yes"; then

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,20 +1,21 @@
 CV_CERTS = DESRCACC100001 DESCHSMCVCA00001
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
-DISTCLEANFILES = opensc.conf.example
+DISTCLEANFILES = opensc.conf opensc.conf.example
 
 EXTRA_DIST = $(CV_CERTS) Makefile.mak
 
 SUFFIXES = .in
 
-dist_noinst_DATA = opensc.conf opensc.conf.example.in
-nodist_noinst_DATA = opensc.conf.example
+dist_noinst_DATA = opensc.conf.in opensc.conf.example.in
+nodist_noinst_DATA = opensc.conf opensc.conf.example
 
 # Make sure we build this every time
 # as there is no dependency for this.
 # Can be removed if MSVC is not required.
 force:
 opensc.conf.example: opensc.conf.example.in force
+opensc.conf: opensc.conf.in force
 
 .in:
 	$(AM_V_GEN)sed \
@@ -23,6 +24,7 @@ opensc.conf.example: opensc.conf.example.in force
 		-e 's|@DEFAULT_PCSC_PROVIDER[@]|$(DEFAULT_PCSC_PROVIDER)|g' \
 		-e 's|@DEFAULT_SM_MODULE[@]|$(DEFAULT_SM_MODULE)|g' \
 		-e 's|@DEFAULT_SM_MODULE_PATH[@]|$(DEFAULT_SM_MODULE_PATH)|g' \
+		-e 's|@DEFAULT_INSTALL_DIR[@]|$(DEFAULT_INSTALL_DIR)|g' \
 		-e 's|@DYN_LIB_EXT[@]|$(DYN_LIB_EXT)|g' \
 		-e 's|@LIBDIR[@]|$(LIBDIR)|g' \
 		-e 's|@LIB_PRE[@]|$(LIB_PRE)|g' \

--- a/etc/opensc.conf.in
+++ b/etc/opensc.conf.in
@@ -3,7 +3,7 @@ app default {
 	# debug_file = opensc-debug.txt;
 	framework pkcs15 {
 		pkcs15init PIV-II {
-			module = "C:\Program Files\OpenSC Project\OpenSC\ishield_piv_module.dll";
+			module = "@DEFAULT_INSTALL_DIR@ishield_piv_module@DYN_LIB_EXT@";
 		}
 	};
 	card_atr 3b:97:11:81:21:75:69:53:68:69:65:6c:64:05 {

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5572,7 +5572,7 @@ static int piv_match_card_continued(sc_card_t *card)
                         r2 = sc_transmit_apdu(card, &apdu); /* on error swissbit_version == 0 */
                         if (apdu.resplen >= 3) {
                                 priv->swissbit_version = (swissbit_version_buf[0] << 16) | (swissbit_version_buf[1] << 8) |
-                                    swissbit_version_buf[2];
+                                                         swissbit_version_buf[2];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
         }

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -5372,7 +5372,7 @@ static int piv_match_card_continued(sc_card_t *card)
 	int saved_type = card->type;
 	sc_apdu_t apdu;
 	u8 yubico_version_buf[3] = {0};
-	u8 swissbit_version_buf[4] = {0};
+	u8 swissbit_version_buf[255] = {0};
 
 	/* piv_match_card may be called with card->type, set by opensc.conf */
 	/* User provided card type must be one we know */
@@ -5570,9 +5570,9 @@ static int piv_match_card_continued(sc_card_t *card)
                         apdu.resplen = sizeof(swissbit_version_buf);
                         apdu.le = apdu.resplen;
                         r2 = sc_transmit_apdu(card, &apdu); /* on error swissbit_version == 0 */
-                        if (apdu.resplen == 4) {
-                                priv->swissbit_version = (swissbit_version_buf[0] << 24) | (swissbit_version_buf[1] << 16) |
-                                    (swissbit_version_buf[2] << 8) | swissbit_version_buf[3];
+                        if (apdu.resplen >= 3) {
+                                priv->swissbit_version = (swissbit_version_buf[0] << 16) | (swissbit_version_buf[1] << 8) |
+                                    swissbit_version_buf[2];
                                 sc_log(card->ctx, "Swissbit card->type=%d, r=0x%08x version=0x%08x", card->type, r, priv->swissbit_version);
                         }
         }
@@ -5702,7 +5702,7 @@ static int piv_match_card_continued(sc_card_t *card)
 
 		case SC_CARD_TYPE_PIV_II_SWISSBIT2:
 			priv->card_issues |= 0; /* could add others here */
-                        if (priv->swissbit_version >= 0x01020000)
+			if (priv->swissbit_version >= 0x00010200)
 				priv->card_issues |= CI_RSA_4096 | CI_EC521;
 			break;
 


### PR DESCRIPTION
- bump version to 0.26.1-swissbit-piv
- adjust PKCS#15 PIV module path in 32bit config
- accept longer responses to GET VERSION for card type SC_CARD_TYPE_PIV_II_SWISSBIT2