### PR TITLE
Fix secure messaging sw mapping

### DIFF
--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -6039,10 +6039,12 @@ static int piv_check_sw(struct sc_card *card, unsigned int sw1, unsigned int sw2
 	/* we do this because 6982 could also mean a verify is not allowed over contactless without VCI */
 	/* we stashed the sw1 and sw2 above for verify */
 	/* Check specific NIST sp800-73-4 SM  errors */
-	for (i = 0; piv_sm_errors[i].SWs != 0; i++) {
-		if (piv_sm_errors[i].SWs == ((sw1 << 8) | sw2)) {
-			sc_log(card->ctx, "%s", piv_sm_errors[i].errorstr);
-			return piv_sm_errors[i].errorno;
+	if (priv && (priv->sm_flags & PIV_SM_FLAGS_SM_IS_ACTIVE)) {
+		for (i = 0; piv_sm_errors[i].SWs != 0; i++) {
+			if (piv_sm_errors[i].SWs == ((sw1 << 8) | sw2)) {
+				sc_log(card->ctx, "%s", piv_sm_errors[i].errorstr);
+				return piv_sm_errors[i].errorno;
+			}
 		}
 	}
 #endif

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -1435,7 +1435,7 @@ err:
 static int piv_free_sm_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t **sm_apdu)
 {
 	int r = SC_SUCCESS;
-	piv_privvate_data_t *priv = PIV_DATA(card);
+	piv_private_data_t *priv = PIV_DATA(card);
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -422,6 +422,7 @@ typedef struct piv_private_data {
 	unsigned long  sm_flags;
 	unsigned char pairing_code[PIV_PAIRING_CODE_LEN]; /* 8 ASCII digits */
 	piv_sm_session_t sm_session;
+	unsigned int last_transport_sw;
 #endif /* ENABLE_PIV_SM */
 } piv_private_data_t;
 
@@ -1434,6 +1435,7 @@ err:
 static int piv_free_sm_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t **sm_apdu)
 {
 	int r = SC_SUCCESS;
+	piv_privvate_data_t *priv = PIV_DATA(card);
 
 	SC_FUNC_CALLED(card->ctx, SC_LOG_DEBUG_VERBOSE);
 
@@ -1443,6 +1445,9 @@ static int piv_free_sm_apdu(sc_card_t *card, sc_apdu_t *plain, sc_apdu_t **sm_ap
 		LOG_FUNC_RETURN(card->ctx, SC_SUCCESS);
 
 	if (plain) {
+		if (priv) {
+			priv->last_transport_sw = (((*sm_apdu)->sw1 << 8) | (*sm_apdu)->sw2);
+		}
 		plain->sw1 = (*sm_apdu)->sw1;
 		plain->sw2 = (*sm_apdu)->sw2;
 		if (((*sm_apdu)->sw1 == 0x90 && (*sm_apdu)->sw2 == 00)
@@ -6040,14 +6045,24 @@ static int piv_check_sw(struct sc_card *card, unsigned int sw1, unsigned int sw2
 	/* we stashed the sw1 and sw2 above for verify */
 	/* Check specific NIST sp800-73-4 SM  errors */
 	if (priv && (priv->sm_flags & PIV_SM_FLAGS_SM_IS_ACTIVE)) {
+		unsigned int mapping_sw = ((sw1 << 8) | sw2);
+
+		if (priv->last_transport_sw == 0x9000 && mapping_sw == 0x6982) {
+			/* special-case the ambiguous 0x6982: inner SW 0x6982 means ISO security status */
+			priv->last_transport_sw = 0;
+			goto iso_fallback;
+		}
+		priv->last_transport_sw = 0;
+
 		for (i = 0; piv_sm_errors[i].SWs != 0; i++) {
-			if (piv_sm_errors[i].SWs == ((sw1 << 8) | sw2)) {
+			if (piv_sm_errors[i].SWs == mapping_sw) {
 				sc_log(card->ctx, "%s", piv_sm_errors[i].errorstr);
 				return piv_sm_errors[i].errorno;
 			}
 		}
 	}
 #endif
+iso_fallback:
 	r = iso_drv->ops->check_sw(card, sw1, sw2);
 	return r;
 }

--- a/src/libopensc/card-piv.c
+++ b/src/libopensc/card-piv.c
@@ -6061,8 +6061,8 @@ static int piv_check_sw(struct sc_card *card, unsigned int sw1, unsigned int sw2
 			}
 		}
 	}
-#endif
 iso_fallback:
+#endif
 	r = iso_drv->ops->check_sw(card, sw1, sw2);
 	return r;
 }

--- a/src/libopensc/pkcs15-sec.c
+++ b/src/libopensc/pkcs15-sec.c
@@ -156,9 +156,7 @@ static int use_key(struct sc_pkcs15_card *p15card,
 		if (revalidated_cached_pin)
 			/* only re-validate once */
 			break;
-		if (r == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED || r == SC_ERROR_SM_NO_SESSION_KEYS) {
-			/* When ENABLE_PIV_SM is set, the status word 6982 is mapped
-			 * to SC_ERROR_SM_NO_SESSION_KEYS for PIV cards */
+		if (r == SC_ERROR_SECURITY_STATUS_NOT_SATISFIED) {
 			r = sc_pkcs15_pincache_revalidate(p15card, obj);
 			if (r < 0)
 				break;


### PR DESCRIPTION
- overwrite SW with secure message SW only when SM is active
- when SM transport SW is 9000 and inner tag SW is 6982, use ISO security status instead of overwriting

