### PR TITLE
use constant time compare for signed integer

### DIFF
--- a/src/common/constant-time.h
+++ b/src/common/constant-time.h
@@ -131,4 +131,20 @@ constant_time_eq_i(int a, int b)
 	return constant_time_eq((unsigned int)a, (unsigned int)b);
 }
 
+/* Signed comparisons */
+
+static constant_inline unsigned int
+constant_time_ge_signed(int a, int b)
+{
+	unsigned int a_u = (unsigned int)a;
+	unsigned int b_u = (unsigned int)b;
+	unsigned int msb_a = constant_time_msb(a_u);
+	unsigned int msb_b = constant_time_msb(b_u);
+	unsigned int sign_diff = msb_a ^ msb_b;
+
+	/* if signs are different, a >= b iff a is positive (msb_a is 0) */
+	/* if signs are same, a >= b iff a_u >= b_u (unsigned) */
+	return constant_time_select(sign_diff, ~msb_a, constant_time_ge(a_u, b_u));
+}
+
 #endif /* CONSTANT_TIME_H */

--- a/src/common/constant-time.h
+++ b/src/common/constant-time.h
@@ -111,6 +111,20 @@ constant_time_ge(unsigned int a, unsigned int b)
 	return ~constant_time_lt(a, b);
 }
 
+static constant_inline unsigned int
+constant_time_ge_i(int a, int b)
+{
+	unsigned int a_u = (unsigned int)a;
+	unsigned int b_u = (unsigned int)b;
+	unsigned int msb_a = constant_time_msb(a_u);
+	unsigned int msb_b = constant_time_msb(b_u);
+	unsigned int sign_diff = msb_a ^ msb_b;
+
+	/* if signs are different, a >= b iff a is positive (msb_a is 0) */
+	/* if signs are same, a >= b iff a_u >= b_u (unsigned) */
+	return constant_time_select(sign_diff, ~msb_a, constant_time_ge(a_u, b_u));
+}
+
 /* Equality*/
 
 static constant_inline unsigned int
@@ -129,22 +143,6 @@ static constant_inline unsigned int
 constant_time_eq_i(int a, int b)
 {
 	return constant_time_eq((unsigned int)a, (unsigned int)b);
-}
-
-/* Signed comparisons */
-
-static constant_inline unsigned int
-constant_time_ge_signed(int a, int b)
-{
-	unsigned int a_u = (unsigned int)a;
-	unsigned int b_u = (unsigned int)b;
-	unsigned int msb_a = constant_time_msb(a_u);
-	unsigned int msb_b = constant_time_msb(b_u);
-	unsigned int sign_diff = msb_a ^ msb_b;
-
-	/* if signs are different, a >= b iff a is positive (msb_a is 0) */
-	/* if signs are same, a >= b iff a_u >= b_u (unsigned) */
-	return constant_time_select(sign_diff, ~msb_a, constant_time_ge(a_u, b_u));
 }
 
 #endif /* CONSTANT_TIME_H */

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4750,7 +4750,7 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 		goto err;
 	}
 
-	good = constant_time_ge(r, 1);
+	good = constant_time_ge_signed(r, 1);
 	/* if no error or padding error, do not return here to prevent Marvin attack */
 	if (!(good | wrong_padding) && r < 0)   {
 		logprintf(pCardData, 2, "sc_pkcs15_decipher error(%i): %s\n", r, sc_strerror(r));

--- a/src/minidriver/minidriver.c
+++ b/src/minidriver/minidriver.c
@@ -4750,7 +4750,7 @@ DWORD WINAPI CardRSADecrypt(__in PCARD_DATA pCardData,
 		goto err;
 	}
 
-	good = constant_time_ge_signed(r, 1);
+	good = constant_time_ge_i(r, 1);
 	/* if no error or padding error, do not return here to prevent Marvin attack */
 	if (!(good | wrong_padding) && r < 0)   {
 		logprintf(pCardData, 2, "sc_pkcs15_decipher error(%i): %s\n", r, sc_strerror(r));


### PR DESCRIPTION
- use constant time compare for signed integer so that CardRSADecrypt does not return success code when decrypt fails